### PR TITLE
Add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,74 @@
+interface Client {
+    new(url: string, hubs: string[]): this
+
+    url: string
+    qs: Qs
+    headers: Headers
+    reconnectDelayTime: number
+    requestTimeout: number
+    callTimeout: number
+    connection: Connection
+
+    on(event: 'connected', listener: (name: string) => void): this
+
+    on(event: 'reconnecting', listener: (count: number) => void): this
+
+    on(event: 'disconnected', listener: (reason: string) => void): this
+
+    on(event: 'error', listener: (code: string, ex?: any) => void): this
+
+    start()
+
+    end()
+}
+
+type Hub = {
+    new(client: Client)
+
+    call(hubName: string, methodName: string, ...args: string[])
+    on(event: string, hubName: string, listener: (message: string) => void): Hub
+    invoke(hubName: string, methodName: string, message: string)
+
+}
+
+declare enum ConnectionState {
+    Connected = 1,
+    Reconnecting = 2,
+    Disconnected = 4,
+}
+
+type ErrorMessages = {
+    invalidURL: 'Invalid URL',
+    invalidProtocol: 'Invalid protocol',
+    noHub: 'No hub',
+    unsupportedWebsocket: 'Websockets is not supported',
+    unauthorized: 'Unauthorized',
+    connectLost: 'Connect lost',
+    negotiateError: 'Negotiate error',
+    startError: 'Start error',
+    connectError: 'Connect error',
+    socketError: 'Socket error',
+    abortError: 'Abort error'
+};
+
+type Connection = {
+    state: ConnectionState,
+    hub: Hub,
+    lastMessageAt: number
+}
+
+interface Headers {
+    [key: string]: string
+}
+
+interface Qs {
+    [key: string]: string
+}
+
+export declare const client: Client
+export declare const error: ErrorMessages
+export declare const connectionState: {
+    connected: 1,
+    reconnecting: 2,
+    disconnected: 4
+}

--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "ws": "^7.2.0"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
### Motivation

Add [typescript definitions ](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)to the project, which allow typescript-projects to get types for this node-signalr library. 

### Is it tested?

For a small project we're doing, and for the code exampled provided in the node-signalr readme, the types should be accurate. However, there may be use cases, nuances, that we did't type 100 % correctly, so feel free to suggest changes.
 



